### PR TITLE
feat: add job for feeding bombastic using bombastic walker

### DIFF
--- a/chart/templates/bombastic/walker/030-Job.yaml
+++ b/chart/templates/bombastic/walker/030-Job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bombastic-walker
+  labels:
+    app.kubernetes.io/name: bombastic-walker
+    app.kubernetes.io/component: walker
+    app.kubernetes.io/part-of: bombastic
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bombastic-walker
+        app.kubernetes.io/component: walker
+        app.kubernetes.io/part-of: bombastic
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        # - image: ghcr.io/trustification/trust:{{ .Values.release }}
+        - image: docker.io/lulf/trust-bombastic-feeder-tmp:latest
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          name: walker
+          command: ["/walker.sh"]
+          args: ["http://bombastic"]

--- a/chart/templates/vexination/csaf/030-Deployment.yaml
+++ b/chart/templates/vexination/csaf/030-Deployment.yaml
@@ -21,10 +21,16 @@ spec:
         app.kubernetes.io/component: csaf
         app.kubernetes.io/part-of: csaf
     spec:
+      volumes:
+        - name: run
+          emptyDir: {}
       containers:
         - image: ghcr.io/trustification/csaf-snapshot:latest
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           name: service
+          volumeMounts:
+            - name: run
+              mountPath: /run
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
@jbtrystram FYI I expect to replace this with the official trustification image when your work is done. For now I pushed a temporary image so that we have the ability to re-feed.